### PR TITLE
Ensure only issues are written to stdout

### DIFF
--- a/bin/ember-watson
+++ b/bin/ember-watson
@@ -4,6 +4,11 @@ var program = require('commander');
 var Watson = require('../index');
 var watson = new Watson();
 
+// Redirect `console.log` so that we are the only ones
+// writing to STDOUT
+var stdout = console.log;
+console.log = console.error;
+
 function collectMultipleArgs(val, memo) {
   memo.push(val);
   return memo;

--- a/bin/ember-watson
+++ b/bin/ember-watson
@@ -6,7 +6,7 @@ var watson = new Watson();
 
 // Redirect `console.log` so that we are the only ones
 // writing to STDOUT
-var stdout = console.log;
+global.stdout = console.log;
 console.log = console.error;
 
 function collectMultipleArgs(val, memo) {

--- a/lib/watson.js
+++ b/lib/watson.js
@@ -64,18 +64,18 @@ function transform(files, transformFormula, checkName, description, dryRun) {
       var newSource = transformFormula(source);
       if (source != newSource) {
         if (dryRun){
-          console.log("%j\0", {
+          stdout("%j\0", {
             type: "Issue",
             check_name: checkName,
             description: description,
             categories: ["Style"],
-            location: { 
-              path: file, 
+            location: {
+              path: file,
               lines: {begin: 1, end: 1}
             }
           })
         } else {
-          console.log(chalk.green('Fixed: ', file));
+          stdout(chalk.green('Fixed: ', file));
 
           fs.writeFileSync(file, newSource);
         }

--- a/lib/watson.js
+++ b/lib/watson.js
@@ -81,6 +81,7 @@ function transform(files, transformFormula, checkName, description, dryRun) {
         }
       }
     } catch (err) {
+      console.error("caught " + err + ", won't fix " + file);
       wontFix.push(file);
     }
   }, this);

--- a/lib/watson.js
+++ b/lib/watson.js
@@ -64,7 +64,7 @@ function transform(files, transformFormula, checkName, description, dryRun) {
       var newSource = transformFormula(source);
       if (source != newSource) {
         if (dryRun){
-          stdout("%j\0", {
+          global.stdout("%j\0", {
             type: "Issue",
             check_name: checkName,
             description: description,
@@ -75,7 +75,7 @@ function transform(files, transformFormula, checkName, description, dryRun) {
             }
           })
         } else {
-          stdout(chalk.green('Fixed: ', file));
+          global.stdout(chalk.green('Fixed: ', file));
 
           fs.writeFileSync(file, newSource);
         }


### PR DESCRIPTION
Quick patch to stop engine errors from happening. We use a similar technique in our eslint engine: globally re-bind `console.log` & expose `stdout` separately for our code.
